### PR TITLE
Add skipDryRunning flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pendulum-chain/api-solang",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Interface to interact with smart contracts compiled via Solang",
   "main": "build/esm/index.js",
   "devDependencies": {


### PR DESCRIPTION
Closes #11 

Unfortunately I had to change the return type of the affected functions and make the `result` entry optional. It is only `undefined` if the parameter `skipDryRunning` is `true`, otherwise it will always be defined – as before.

It is possible to define this relationship in TypeScript but I think that the types will be ugly. Therefore I keep it as it is. This would now require the caller to explicitly check whether the `result` entry is `undefined` or not (or just assure it using the `!` operator).