### PR TITLE
Expose more parameters from extrinsic submission result to callers

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore artifacts:
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": false,
+  "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "trailingComma": "es5",
   "tabWidth": 2,
-  "semi": false
+  "semi": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "printWidth": 120,
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "trailingComma": "es5",
-  "tabWidth": 4,
-  "semi": false,
-  "singleQuote": true
+  "tabWidth": 2,
+  "semi": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "@pendulum-chain/api-solang",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pendulum-chain/api-solang",
-      "version": "0.3.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.6.0",
+        "husky": ">=6",
+        "lint-staged": ">=10",
+        "prettier": "^3.3.3",
         "rimraf": "^5.0.1",
         "typescript": "^5.2.2"
       },
@@ -748,6 +751,21 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "dev": true,
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -793,6 +811,84 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -810,6 +906,21 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -835,12 +946,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "peer": true,
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -863,11 +973,45 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "peer": true
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -890,6 +1034,18 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/foreground-child": {
@@ -920,6 +1076,30 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "10.3.13",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.13.tgz",
@@ -942,6 +1122,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
+      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -949,6 +1153,27 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -981,6 +1206,192 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "peer": true
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.2.10",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
+      "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~5.3.0",
+        "commander": "~12.1.0",
+        "debug": "~4.3.6",
+        "execa": "~8.0.1",
+        "lilconfig": "~3.1.2",
+        "listr2": "~8.2.4",
+        "micromatch": "~4.0.8",
+        "pidtree": "~0.6.0",
+        "string-argv": "~0.3.2",
+        "yaml": "~2.5.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.4.tgz",
+      "integrity": "sha512-opevsywziHd3zHCVQGAj8zu+Z3yHNkkoYhWIGnq54RrCVwLz0MozotJEDnKsIBLvkfLGN6BLOyAeRrYI0pKA4g==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
@@ -988,6 +1399,49 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -1024,10 +1478,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nock": {
       "version": "13.5.4",
@@ -1080,6 +1533,48 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1105,6 +1600,45 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -1113,6 +1647,43 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "5.0.5",
@@ -1181,6 +1752,34 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smoldot": {
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.22.tgz",
@@ -1189,6 +1788,15 @@
       "peer": true,
       "dependencies": {
         "ws": "^8.8.1"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -1285,6 +1893,30 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tslib": {
@@ -1445,6 +2077,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "build/esm/index.js",
   "devDependencies": {
     "@types/node": "^20.6.0",
+    "husky": ">=6",
+    "lint-staged": ">=10",
+    "prettier": "^3.3.3",
     "rimraf": "^5.0.1",
     "typescript": "^5.2.2"
   },
@@ -24,7 +27,8 @@
     "prepublishOnly": "npm run build",
     "simplyPublish": "npm publish --workspace @pendulum-chain/api-solang --access public",
     "compile": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.types.json",
-    "build": "npm run clean && npm run compile"
+    "build": "npm run clean && npm run compile",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -57,5 +61,8 @@
       "import": "./build/esm/*.js",
       "default": "./build/esm/*.js"
     }
+  },
+  "lint-staged": {
+    "*.{js,ts,css,md}": "prettier --write"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pendulum-chain/api-solang",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Interface to interact with smart contracts compiled via Solang",
   "main": "build/esm/index.js",
   "devDependencies": {

--- a/src/contractRpc.ts
+++ b/src/contractRpc.ts
@@ -1,54 +1,54 @@
-import { ApiPromise } from "@polkadot/api";
-import { Abi } from "@polkadot/api-contract";
+import { ApiPromise } from "@polkadot/api"
+import { Abi } from "@polkadot/api-contract"
 import {
   ContractExecResult,
   ContractExecResultOk,
   ContractInstantiateResult,
   Weight,
-} from "@polkadot/types/interfaces";
-import { BN_ZERO } from "@polkadot/util";
-import { TypeDef } from "@polkadot/types/types";
+} from "@polkadot/types/interfaces"
+import { BN_ZERO } from "@polkadot/util"
+import { TypeDef } from "@polkadot/types/types"
 
-import { Address, Limits } from "./index.js";
-import { extractDispatchErrorDescription } from "./dispatchError.js";
+import { Address, Limits } from "./index.js"
+import { extractDispatchErrorDescription } from "./dispatchError.js"
 
 export interface QueryContractOptions {
-  api: ApiPromise;
-  abi: Abi;
-  contractAddress: Address;
-  callerAddress: Address;
-  messageName: string;
-  limits: Limits;
-  messageArguments: unknown[];
+  api: ApiPromise
+  abi: Abi
+  contractAddress: Address
+  callerAddress: Address
+  messageName: string
+  limits: Limits
+  messageArguments: unknown[]
 }
 
-export type PanicCode = number;
+export type PanicCode = number
 
 // error explanations taken from https://docs.soliditylang.org/en/v0.8.20/control-structures.html#panic-via-assert-and-error-via-require
 export function explainPanicError(errorCode: PanicCode): string {
   switch (errorCode) {
     case 0x00:
-      return "Used for generic compiler inserted panics.";
+      return "Used for generic compiler inserted panics."
     case 0x01:
-      return "Assert called with an argument that evaluated to false.";
+      return "Assert called with an argument that evaluated to false."
     case 0x11:
-      return "Arithmetic operation resulted in underflow or overflow outside of an unchecked { ... } block.";
+      return "Arithmetic operation resulted in underflow or overflow outside of an unchecked { ... } block."
     case 0x12:
-      return "Division or modulo by zero (e.g. 5 / 0 or 23 % 0).";
+      return "Division or modulo by zero (e.g. 5 / 0 or 23 % 0)."
     case 0x21:
-      return "Converted a value that is too big or negative into an enum type.";
+      return "Converted a value that is too big or negative into an enum type."
     case 0x22:
-      return "Accessed a storage byte array that is incorrectly encoded.";
+      return "Accessed a storage byte array that is incorrectly encoded."
     case 0x31:
-      return "Called .pop() on an empty array.";
+      return "Called .pop() on an empty array."
     case 0x32:
-      return "Accessed an array, bytesN or an array slice at an out-of-bounds or negative index (i.e. x[i] where i >= x.length or i < 0).";
+      return "Accessed an array, bytesN or an array slice at an out-of-bounds or negative index (i.e. x[i] where i >= x.length or i < 0)."
     case 0x41:
-      return "Allocated too much memory or create an array that is too large.";
+      return "Allocated too much memory or create an array that is too large."
     case 0x51:
-      return "Called a zero-initialized variable of internal function type.";
+      return "Called a zero-initialized variable of internal function type."
     default:
-      return "Unknown panic error";
+      return "Unknown panic error"
   }
 }
 
@@ -56,12 +56,12 @@ export type QueryContractOutput =
   | { type: "success"; value: any }
   | { type: "reverted"; description: string }
   | { type: "panic"; errorCode: PanicCode; explanation: string }
-  | { type: "error"; description?: string };
+  | { type: "error"; description?: string }
 
 export interface QueryContractResult {
-  gasRequired: Weight;
-  gasConsumed: Weight;
-  output: QueryContractOutput;
+  gasRequired: Weight
+  gasConsumed: Weight
+  output: QueryContractOutput
 }
 
 function extractContractExecutionOutput(
@@ -70,20 +70,27 @@ function extractContractExecutionOutput(
   result: ContractExecResultOk,
   returnType: TypeDef | null | undefined
 ): QueryContractOutput {
-  const data = result.data.toU8a(true);
+  const data = result.data.toU8a(true)
   if (!result.flags.isRevert) {
     const value = returnType
-      ? abi.registry.createTypeUnsafe(returnType.lookupName || returnType.type, [data], {
-          isPedantic: true,
-        })
-      : undefined;
-    return { type: "success", value };
+      ? abi.registry.createTypeUnsafe(
+          returnType.lookupName || returnType.type,
+          [data],
+          {
+            isPedantic: true,
+          }
+        )
+      : undefined
+    return { type: "success", value }
   } else {
-    const dataView = new DataView(data.buffer);
-    const prefix = data.buffer.byteLength >= 4 ? dataView.getUint32(0) : 0;
+    const dataView = new DataView(data.buffer)
+    const prefix = data.buffer.byteLength >= 4 ? dataView.getUint32(0) : 0
     switch (prefix) {
       case 0x08c379a0:
-        return { type: "reverted", description: api.createType("String", data.slice(4)).toString() };
+        return {
+          type: "reverted",
+          description: api.createType("String", data.slice(4)).toString(),
+        }
 
       case 0x4e487b71:
         try {
@@ -93,17 +100,17 @@ function extractContractExecutionOutput(
                 2n ** 64n * dataView.getBigUint64(12, true) +
                 2n ** 128n * dataView.getBigUint64(20, true) +
                 2n ** 192n * dataView.getBigUint64(28, true)
-              : -1n;
+              : -1n
 
           return {
             type: "panic",
             errorCode: Number(errorCode),
             explanation: explainPanicError(Number(errorCode)),
-          };
+          }
         } catch {}
 
       default:
-        return { type: "error" };
+        return { type: "error" }
     }
   }
 }
@@ -117,9 +124,9 @@ export async function rpcCall({
   limits,
   messageArguments,
 }: QueryContractOptions): Promise<QueryContractResult> {
-  let resolved = false;
+  let resolved = false
   return new Promise<QueryContractResult>((resolve) => {
-    const message = abi.findMessage(messageName);
+    const message = abi.findMessage(messageName)
 
     const observable = api.rx.call.contractsApi.call<ContractExecResult>(
       callerAddress,
@@ -128,40 +135,48 @@ export async function rpcCall({
       api.createType("WeightV2", limits.gas),
       limits.storageDeposit,
       message.toU8a(messageArguments)
-    );
+    )
 
     observable.forEach((event) => {
       if (resolved) {
-        return;
+        return
       }
-      resolved = true;
+      resolved = true
 
-      const { result, gasRequired, gasConsumed } = event;
+      const { result, gasRequired, gasConsumed } = event
 
       if (result.isOk) {
         resolve({
           gasRequired,
           gasConsumed,
-          output: extractContractExecutionOutput(api, abi, result.asOk, message.returnType),
-        });
+          output: extractContractExecutionOutput(
+            api,
+            abi,
+            result.asOk,
+            message.returnType
+          ),
+        })
       } else {
         resolve({
           gasRequired,
           gasConsumed,
-          output: { type: "error", description: extractDispatchErrorDescription(result.asErr) },
-        });
+          output: {
+            type: "error",
+            description: extractDispatchErrorDescription(result.asErr),
+          },
+        })
       }
-    });
-  });
+    })
+  })
 }
 
 export interface QueryInstantiateContractOptions {
-  api: ApiPromise;
-  abi: Abi;
-  callerAddress: Address;
-  constructorName: string;
-  limits: Limits;
-  constructorArguments: unknown[];
+  api: ApiPromise
+  abi: Abi
+  callerAddress: Address
+  constructorName: string
+  limits: Limits
+  constructorArguments: unknown[]
 }
 
 export async function rpcInstantiate({
@@ -172,46 +187,55 @@ export async function rpcInstantiate({
   limits,
   constructorArguments,
 }: QueryInstantiateContractOptions): Promise<QueryContractResult> {
-  let resolved = false;
+  let resolved = false
 
   return new Promise<QueryContractResult>((resolve) => {
-    const constructor = abi.findConstructor(constructorName);
-    const data = constructor.toU8a(constructorArguments);
-    const salt = new Uint8Array();
+    const constructor = abi.findConstructor(constructorName)
+    const data = constructor.toU8a(constructorArguments)
+    const salt = new Uint8Array()
 
     //const code = api.createType("Code", { Upload: abi.info.source.wasm });
 
-    const observable = api.rx.call.contractsApi.instantiate<ContractInstantiateResult>(
-      callerAddress,
-      BN_ZERO,
-      api.createType("WeightV2", limits.gas),
-      limits.storageDeposit,
-      { Upload: abi.info.source.wasm },
-      data,
-      salt
-    );
+    const observable =
+      api.rx.call.contractsApi.instantiate<ContractInstantiateResult>(
+        callerAddress,
+        BN_ZERO,
+        api.createType("WeightV2", limits.gas),
+        limits.storageDeposit,
+        { Upload: abi.info.source.wasm },
+        data,
+        salt
+      )
 
     observable.forEach((event) => {
       if (resolved) {
-        return;
+        return
       }
-      resolved = true;
+      resolved = true
 
-      const { result, gasRequired, gasConsumed } = event;
+      const { result, gasRequired, gasConsumed } = event
 
       if (result.isOk) {
         resolve({
           gasRequired,
           gasConsumed,
-          output: extractContractExecutionOutput(api, abi, result.asOk.result, constructor.returnType),
-        });
+          output: extractContractExecutionOutput(
+            api,
+            abi,
+            result.asOk.result,
+            constructor.returnType
+          ),
+        })
       } else {
         resolve({
           gasRequired,
           gasConsumed,
-          output: { type: "error", description: extractDispatchErrorDescription(result.asErr) },
-        });
+          output: {
+            type: "error",
+            description: extractDispatchErrorDescription(result.asErr),
+          },
+        })
       }
-    });
-  });
+    })
+  })
 }

--- a/src/contractRpc.ts
+++ b/src/contractRpc.ts
@@ -1,54 +1,54 @@
-import { ApiPromise } from "@polkadot/api"
-import { Abi } from "@polkadot/api-contract"
+import { ApiPromise } from "@polkadot/api";
+import { Abi } from "@polkadot/api-contract";
 import {
   ContractExecResult,
   ContractExecResultOk,
   ContractInstantiateResult,
   Weight,
-} from "@polkadot/types/interfaces"
-import { BN_ZERO } from "@polkadot/util"
-import { TypeDef } from "@polkadot/types/types"
+} from "@polkadot/types/interfaces";
+import { BN_ZERO } from "@polkadot/util";
+import { TypeDef } from "@polkadot/types/types";
 
-import { Address, Limits } from "./index.js"
-import { extractDispatchErrorDescription } from "./dispatchError.js"
+import { Address, Limits } from "./index.js";
+import { extractDispatchErrorDescription } from "./dispatchError.js";
 
 export interface QueryContractOptions {
-  api: ApiPromise
-  abi: Abi
-  contractAddress: Address
-  callerAddress: Address
-  messageName: string
-  limits: Limits
-  messageArguments: unknown[]
+  api: ApiPromise;
+  abi: Abi;
+  contractAddress: Address;
+  callerAddress: Address;
+  messageName: string;
+  limits: Limits;
+  messageArguments: unknown[];
 }
 
-export type PanicCode = number
+export type PanicCode = number;
 
 // error explanations taken from https://docs.soliditylang.org/en/v0.8.20/control-structures.html#panic-via-assert-and-error-via-require
 export function explainPanicError(errorCode: PanicCode): string {
   switch (errorCode) {
     case 0x00:
-      return "Used for generic compiler inserted panics."
+      return "Used for generic compiler inserted panics.";
     case 0x01:
-      return "Assert called with an argument that evaluated to false."
+      return "Assert called with an argument that evaluated to false.";
     case 0x11:
-      return "Arithmetic operation resulted in underflow or overflow outside of an unchecked { ... } block."
+      return "Arithmetic operation resulted in underflow or overflow outside of an unchecked { ... } block.";
     case 0x12:
-      return "Division or modulo by zero (e.g. 5 / 0 or 23 % 0)."
+      return "Division or modulo by zero (e.g. 5 / 0 or 23 % 0).";
     case 0x21:
-      return "Converted a value that is too big or negative into an enum type."
+      return "Converted a value that is too big or negative into an enum type.";
     case 0x22:
-      return "Accessed a storage byte array that is incorrectly encoded."
+      return "Accessed a storage byte array that is incorrectly encoded.";
     case 0x31:
-      return "Called .pop() on an empty array."
+      return "Called .pop() on an empty array.";
     case 0x32:
-      return "Accessed an array, bytesN or an array slice at an out-of-bounds or negative index (i.e. x[i] where i >= x.length or i < 0)."
+      return "Accessed an array, bytesN or an array slice at an out-of-bounds or negative index (i.e. x[i] where i >= x.length or i < 0).";
     case 0x41:
-      return "Allocated too much memory or create an array that is too large."
+      return "Allocated too much memory or create an array that is too large.";
     case 0x51:
-      return "Called a zero-initialized variable of internal function type."
+      return "Called a zero-initialized variable of internal function type.";
     default:
-      return "Unknown panic error"
+      return "Unknown panic error";
   }
 }
 
@@ -56,12 +56,12 @@ export type QueryContractOutput =
   | { type: "success"; value: any }
   | { type: "reverted"; description: string }
   | { type: "panic"; errorCode: PanicCode; explanation: string }
-  | { type: "error"; description?: string }
+  | { type: "error"; description?: string };
 
 export interface QueryContractResult {
-  gasRequired: Weight
-  gasConsumed: Weight
-  output: QueryContractOutput
+  gasRequired: Weight;
+  gasConsumed: Weight;
+  output: QueryContractOutput;
 }
 
 function extractContractExecutionOutput(
@@ -70,7 +70,7 @@ function extractContractExecutionOutput(
   result: ContractExecResultOk,
   returnType: TypeDef | null | undefined
 ): QueryContractOutput {
-  const data = result.data.toU8a(true)
+  const data = result.data.toU8a(true);
   if (!result.flags.isRevert) {
     const value = returnType
       ? abi.registry.createTypeUnsafe(
@@ -80,17 +80,17 @@ function extractContractExecutionOutput(
             isPedantic: true,
           }
         )
-      : undefined
-    return { type: "success", value }
+      : undefined;
+    return { type: "success", value };
   } else {
-    const dataView = new DataView(data.buffer)
-    const prefix = data.buffer.byteLength >= 4 ? dataView.getUint32(0) : 0
+    const dataView = new DataView(data.buffer);
+    const prefix = data.buffer.byteLength >= 4 ? dataView.getUint32(0) : 0;
     switch (prefix) {
       case 0x08c379a0:
         return {
           type: "reverted",
           description: api.createType("String", data.slice(4)).toString(),
-        }
+        };
 
       case 0x4e487b71:
         try {
@@ -100,17 +100,17 @@ function extractContractExecutionOutput(
                 2n ** 64n * dataView.getBigUint64(12, true) +
                 2n ** 128n * dataView.getBigUint64(20, true) +
                 2n ** 192n * dataView.getBigUint64(28, true)
-              : -1n
+              : -1n;
 
           return {
             type: "panic",
             errorCode: Number(errorCode),
             explanation: explainPanicError(Number(errorCode)),
-          }
+          };
         } catch {}
 
       default:
-        return { type: "error" }
+        return { type: "error" };
     }
   }
 }
@@ -124,9 +124,9 @@ export async function rpcCall({
   limits,
   messageArguments,
 }: QueryContractOptions): Promise<QueryContractResult> {
-  let resolved = false
+  let resolved = false;
   return new Promise<QueryContractResult>((resolve) => {
-    const message = abi.findMessage(messageName)
+    const message = abi.findMessage(messageName);
 
     const observable = api.rx.call.contractsApi.call<ContractExecResult>(
       callerAddress,
@@ -135,15 +135,15 @@ export async function rpcCall({
       api.createType("WeightV2", limits.gas),
       limits.storageDeposit,
       message.toU8a(messageArguments)
-    )
+    );
 
     observable.forEach((event) => {
       if (resolved) {
-        return
+        return;
       }
-      resolved = true
+      resolved = true;
 
-      const { result, gasRequired, gasConsumed } = event
+      const { result, gasRequired, gasConsumed } = event;
 
       if (result.isOk) {
         resolve({
@@ -155,7 +155,7 @@ export async function rpcCall({
             result.asOk,
             message.returnType
           ),
-        })
+        });
       } else {
         resolve({
           gasRequired,
@@ -164,19 +164,19 @@ export async function rpcCall({
             type: "error",
             description: extractDispatchErrorDescription(result.asErr),
           },
-        })
+        });
       }
-    })
-  })
+    });
+  });
 }
 
 export interface QueryInstantiateContractOptions {
-  api: ApiPromise
-  abi: Abi
-  callerAddress: Address
-  constructorName: string
-  limits: Limits
-  constructorArguments: unknown[]
+  api: ApiPromise;
+  abi: Abi;
+  callerAddress: Address;
+  constructorName: string;
+  limits: Limits;
+  constructorArguments: unknown[];
 }
 
 export async function rpcInstantiate({
@@ -187,12 +187,12 @@ export async function rpcInstantiate({
   limits,
   constructorArguments,
 }: QueryInstantiateContractOptions): Promise<QueryContractResult> {
-  let resolved = false
+  let resolved = false;
 
   return new Promise<QueryContractResult>((resolve) => {
-    const constructor = abi.findConstructor(constructorName)
-    const data = constructor.toU8a(constructorArguments)
-    const salt = new Uint8Array()
+    const constructor = abi.findConstructor(constructorName);
+    const data = constructor.toU8a(constructorArguments);
+    const salt = new Uint8Array();
 
     //const code = api.createType("Code", { Upload: abi.info.source.wasm });
 
@@ -205,15 +205,15 @@ export async function rpcInstantiate({
         { Upload: abi.info.source.wasm },
         data,
         salt
-      )
+      );
 
     observable.forEach((event) => {
       if (resolved) {
-        return
+        return;
       }
-      resolved = true
+      resolved = true;
 
-      const { result, gasRequired, gasConsumed } = event
+      const { result, gasRequired, gasConsumed } = event;
 
       if (result.isOk) {
         resolve({
@@ -225,7 +225,7 @@ export async function rpcInstantiate({
             result.asOk.result,
             constructor.returnType
           ),
-        })
+        });
       } else {
         resolve({
           gasRequired,
@@ -234,8 +234,8 @@ export async function rpcInstantiate({
             type: "error",
             description: extractDispatchErrorDescription(result.asErr),
           },
-        })
+        });
       }
-    })
-  })
+    });
+  });
 }

--- a/src/contractRpc.ts
+++ b/src/contractRpc.ts
@@ -73,13 +73,9 @@ function extractContractExecutionOutput(
   const data = result.data.toU8a(true);
   if (!result.flags.isRevert) {
     const value = returnType
-      ? abi.registry.createTypeUnsafe(
-          returnType.lookupName || returnType.type,
-          [data],
-          {
-            isPedantic: true,
-          }
-        )
+      ? abi.registry.createTypeUnsafe(returnType.lookupName || returnType.type, [data], {
+          isPedantic: true,
+        })
       : undefined;
     return { type: "success", value };
   } else {
@@ -149,12 +145,7 @@ export async function rpcCall({
         resolve({
           gasRequired,
           gasConsumed,
-          output: extractContractExecutionOutput(
-            api,
-            abi,
-            result.asOk,
-            message.returnType
-          ),
+          output: extractContractExecutionOutput(api, abi, result.asOk, message.returnType),
         });
       } else {
         resolve({
@@ -196,16 +187,15 @@ export async function rpcInstantiate({
 
     //const code = api.createType("Code", { Upload: abi.info.source.wasm });
 
-    const observable =
-      api.rx.call.contractsApi.instantiate<ContractInstantiateResult>(
-        callerAddress,
-        BN_ZERO,
-        api.createType("WeightV2", limits.gas),
-        limits.storageDeposit,
-        { Upload: abi.info.source.wasm },
-        data,
-        salt
-      );
+    const observable = api.rx.call.contractsApi.instantiate<ContractInstantiateResult>(
+      callerAddress,
+      BN_ZERO,
+      api.createType("WeightV2", limits.gas),
+      limits.storageDeposit,
+      { Upload: abi.info.source.wasm },
+      data,
+      salt
+    );
 
     observable.forEach((event) => {
       if (resolved) {
@@ -219,12 +209,7 @@ export async function rpcInstantiate({
         resolve({
           gasRequired,
           gasConsumed,
-          output: extractContractExecutionOutput(
-            api,
-            abi,
-            result.asOk.result,
-            constructor.returnType
-          ),
+          output: extractContractExecutionOutput(api, abi, result.asOk.result, constructor.returnType),
         });
       } else {
         resolve({

--- a/src/deployContract.ts
+++ b/src/deployContract.ts
@@ -1,33 +1,38 @@
-import { ApiPromise } from "@polkadot/api";
-import { CodePromise, Abi } from "@polkadot/api-contract";
-import { AccountId, EventRecord } from "@polkadot/types/interfaces";
-import { ITuple } from "@polkadot/types-codec/types";
+import { ApiPromise } from "@polkadot/api"
+import { CodePromise, Abi } from "@polkadot/api-contract"
+import { AccountId, EventRecord } from "@polkadot/types/interfaces"
+import { ITuple } from "@polkadot/types-codec/types"
 
-import { Limits, Address } from "./index.js";
+import { Limits, Address } from "./index.js"
 import {
   Extrinsic,
   GenericSigner,
   KeyPairSigner,
   getSignerAddress,
   signAndSubmitExtrinsic,
-} from "./submitExtrinsic.js";
-import { PanicCode, rpcInstantiate } from "./contractRpc.js";
+} from "./submitExtrinsic.js"
+import { PanicCode, rpcInstantiate } from "./contractRpc.js"
 
 export interface BasicDeployContractOptions {
-  api: ApiPromise;
-  abi: Abi;
-  constructorArguments: unknown[];
-  constructorName?: string;
-  limits: Limits;
-  signer: KeyPairSigner | GenericSigner;
-  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic;
+  api: ApiPromise
+  abi: Abi
+  constructorArguments: unknown[]
+  constructorName?: string
+  limits: Limits
+  signer: KeyPairSigner | GenericSigner
+  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic
 }
 
 export type BasicDeployContractResult =
-  | { type: "success"; eventRecords: EventRecord[]; deploymentAddress: Address; transactionFee: bigint | undefined }
+  | {
+      type: "success"
+      eventRecords: EventRecord[]
+      deploymentAddress: Address
+      transactionFee: bigint | undefined
+    }
   | { type: "error"; error: string }
   | { type: "reverted"; description: string }
-  | { type: "panic"; errorCode: PanicCode; explanation: string };
+  | { type: "panic"; errorCode: PanicCode; explanation: string }
 
 export async function basicDeployContract({
   api,
@@ -38,13 +43,13 @@ export async function basicDeployContract({
   signer,
   modifyExtrinsic,
 }: BasicDeployContractOptions): Promise<BasicDeployContractResult> {
-  const code = new CodePromise(api, abi, undefined);
+  const code = new CodePromise(api, abi, undefined)
 
-  constructorName = constructorName ?? "new";
+  constructorName = constructorName ?? "new"
   try {
-    abi.findConstructor(constructorName);
+    abi.findConstructor(constructorName)
   } catch {
-    throw new Error(`Contract has no constructor called ${constructorName}`);
+    throw new Error(`Contract has no constructor called ${constructorName}`)
   }
 
   const { gasRequired, output } = await rpcInstantiate({
@@ -54,44 +59,53 @@ export async function basicDeployContract({
     constructorName,
     limits,
     constructorArguments,
-  });
+  })
 
   switch (output.type) {
     case "reverted":
     case "panic":
-      return output;
+      return output
 
     case "error":
-      return { type: "error", error: output.description ?? "unknown" };
+      return { type: "error", error: output.description ?? "unknown" }
   }
 
-  const { storageDeposit: storageDepositLimit } = limits;
+  const { storageDeposit: storageDepositLimit } = limits
 
-  let extrinsic = code.tx[constructorName]({ gasLimit: gasRequired, storageDepositLimit }, ...constructorArguments);
+  let extrinsic = code.tx[constructorName](
+    { gasLimit: gasRequired, storageDepositLimit },
+    ...constructorArguments
+  )
 
   if (modifyExtrinsic) {
-    extrinsic = modifyExtrinsic(extrinsic);
+    extrinsic = modifyExtrinsic(extrinsic)
   }
-  const { eventRecords, status, transactionFee } = await signAndSubmitExtrinsic(extrinsic, signer);
+  const { eventRecords, status, transactionFee } = await signAndSubmitExtrinsic(
+    extrinsic,
+    signer
+  )
 
   if (status.type === "error") {
-    return { type: "error", error: `Contract could not be deployed: ${status.error}` };
+    return {
+      type: "error",
+      error: `Contract could not be deployed: ${status.error}`,
+    }
   }
 
-  let deploymentAddress: Address | undefined = undefined;
+  let deploymentAddress: Address | undefined = undefined
 
   for (const eventRecord of eventRecords) {
-    const { data, section, method } = eventRecord.event;
+    const { data, section, method } = eventRecord.event
 
     if (section === "contracts" && method === "Instantiated") {
-      const [, contract] = data as unknown as ITuple<[AccountId, AccountId]>;
-      deploymentAddress = contract.toString() as Address;
+      const [, contract] = data as unknown as ITuple<[AccountId, AccountId]>
+      deploymentAddress = contract.toString() as Address
     }
   }
 
   if (deploymentAddress === undefined) {
-    return { type: "error", error: "Contract address not found" };
+    return { type: "error", error: "Contract address not found" }
   }
 
-  return { type: "success", deploymentAddress, eventRecords, transactionFee };
+  return { type: "success", deploymentAddress, eventRecords, transactionFee }
 }

--- a/src/deployContract.ts
+++ b/src/deployContract.ts
@@ -1,38 +1,38 @@
-import { ApiPromise } from "@polkadot/api"
-import { CodePromise, Abi } from "@polkadot/api-contract"
-import { AccountId, EventRecord } from "@polkadot/types/interfaces"
-import { ITuple } from "@polkadot/types-codec/types"
+import { ApiPromise } from "@polkadot/api";
+import { CodePromise, Abi } from "@polkadot/api-contract";
+import { AccountId, EventRecord } from "@polkadot/types/interfaces";
+import { ITuple } from "@polkadot/types-codec/types";
 
-import { Limits, Address } from "./index.js"
+import { Limits, Address } from "./index.js";
 import {
   Extrinsic,
   GenericSigner,
   KeyPairSigner,
   getSignerAddress,
   signAndSubmitExtrinsic,
-} from "./submitExtrinsic.js"
-import { PanicCode, rpcInstantiate } from "./contractRpc.js"
+} from "./submitExtrinsic.js";
+import { PanicCode, rpcInstantiate } from "./contractRpc.js";
 
 export interface BasicDeployContractOptions {
-  api: ApiPromise
-  abi: Abi
-  constructorArguments: unknown[]
-  constructorName?: string
-  limits: Limits
-  signer: KeyPairSigner | GenericSigner
-  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic
+  api: ApiPromise;
+  abi: Abi;
+  constructorArguments: unknown[];
+  constructorName?: string;
+  limits: Limits;
+  signer: KeyPairSigner | GenericSigner;
+  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic;
 }
 
 export type BasicDeployContractResult =
   | {
-      type: "success"
-      eventRecords: EventRecord[]
-      deploymentAddress: Address
-      transactionFee: bigint | undefined
+      type: "success";
+      eventRecords: EventRecord[];
+      deploymentAddress: Address;
+      transactionFee: bigint | undefined;
     }
   | { type: "error"; error: string }
   | { type: "reverted"; description: string }
-  | { type: "panic"; errorCode: PanicCode; explanation: string }
+  | { type: "panic"; errorCode: PanicCode; explanation: string };
 
 export async function basicDeployContract({
   api,
@@ -43,13 +43,13 @@ export async function basicDeployContract({
   signer,
   modifyExtrinsic,
 }: BasicDeployContractOptions): Promise<BasicDeployContractResult> {
-  const code = new CodePromise(api, abi, undefined)
+  const code = new CodePromise(api, abi, undefined);
 
-  constructorName = constructorName ?? "new"
+  constructorName = constructorName ?? "new";
   try {
-    abi.findConstructor(constructorName)
+    abi.findConstructor(constructorName);
   } catch {
-    throw new Error(`Contract has no constructor called ${constructorName}`)
+    throw new Error(`Contract has no constructor called ${constructorName}`);
   }
 
   const { gasRequired, output } = await rpcInstantiate({
@@ -59,53 +59,53 @@ export async function basicDeployContract({
     constructorName,
     limits,
     constructorArguments,
-  })
+  });
 
   switch (output.type) {
     case "reverted":
     case "panic":
-      return output
+      return output;
 
     case "error":
-      return { type: "error", error: output.description ?? "unknown" }
+      return { type: "error", error: output.description ?? "unknown" };
   }
 
-  const { storageDeposit: storageDepositLimit } = limits
+  const { storageDeposit: storageDepositLimit } = limits;
 
   let extrinsic = code.tx[constructorName](
     { gasLimit: gasRequired, storageDepositLimit },
     ...constructorArguments
-  )
+  );
 
   if (modifyExtrinsic) {
-    extrinsic = modifyExtrinsic(extrinsic)
+    extrinsic = modifyExtrinsic(extrinsic);
   }
   const { eventRecords, status, transactionFee } = await signAndSubmitExtrinsic(
     extrinsic,
     signer
-  )
+  );
 
   if (status.type === "error") {
     return {
       type: "error",
       error: `Contract could not be deployed: ${status.error}`,
-    }
+    };
   }
 
-  let deploymentAddress: Address | undefined = undefined
+  let deploymentAddress: Address | undefined = undefined;
 
   for (const eventRecord of eventRecords) {
-    const { data, section, method } = eventRecord.event
+    const { data, section, method } = eventRecord.event;
 
     if (section === "contracts" && method === "Instantiated") {
-      const [, contract] = data as unknown as ITuple<[AccountId, AccountId]>
-      deploymentAddress = contract.toString() as Address
+      const [, contract] = data as unknown as ITuple<[AccountId, AccountId]>;
+      deploymentAddress = contract.toString() as Address;
     }
   }
 
   if (deploymentAddress === undefined) {
-    return { type: "error", error: "Contract address not found" }
+    return { type: "error", error: "Contract address not found" };
   }
 
-  return { type: "success", deploymentAddress, eventRecords, transactionFee }
+  return { type: "success", deploymentAddress, eventRecords, transactionFee };
 }

--- a/src/deployContract.ts
+++ b/src/deployContract.ts
@@ -72,18 +72,12 @@ export async function basicDeployContract({
 
   const { storageDeposit: storageDepositLimit } = limits;
 
-  let extrinsic = code.tx[constructorName](
-    { gasLimit: gasRequired, storageDepositLimit },
-    ...constructorArguments
-  );
+  let extrinsic = code.tx[constructorName]({ gasLimit: gasRequired, storageDepositLimit }, ...constructorArguments);
 
   if (modifyExtrinsic) {
     extrinsic = modifyExtrinsic(extrinsic);
   }
-  const { eventRecords, status, transactionFee } = await signAndSubmitExtrinsic(
-    extrinsic,
-    signer
-  );
+  const { eventRecords, status, transactionFee } = await signAndSubmitExtrinsic(extrinsic, signer);
 
   if (status.type === "error") {
     return {

--- a/src/dispatchError.ts
+++ b/src/dispatchError.ts
@@ -1,14 +1,19 @@
-import { DispatchError } from "@polkadot/types/interfaces";
+import { DispatchError } from "@polkadot/types/interfaces"
 
-export function extractDispatchErrorDescription(dispatchError: DispatchError): string {
+export function extractDispatchErrorDescription(
+  dispatchError: DispatchError
+): string {
   if (dispatchError.isModule) {
     try {
-      const module = dispatchError.asModule;
-      const error = dispatchError.registry.findMetaError(module);
+      const module = dispatchError.asModule
+      const error = dispatchError.registry.findMetaError(module)
 
-      return `${error.section}.${error.name}: ${error.docs[0]}` ?? `${error.section}.${error.name}`;
+      return (
+        `${error.section}.${error.name}: ${error.docs[0]}` ??
+        `${error.section}.${error.name}`
+      )
     } catch {}
   }
 
-  return dispatchError.type.toString();
+  return dispatchError.type.toString()
 }

--- a/src/dispatchError.ts
+++ b/src/dispatchError.ts
@@ -1,17 +1,12 @@
 import { DispatchError } from "@polkadot/types/interfaces";
 
-export function extractDispatchErrorDescription(
-  dispatchError: DispatchError
-): string {
+export function extractDispatchErrorDescription(dispatchError: DispatchError): string {
   if (dispatchError.isModule) {
     try {
       const module = dispatchError.asModule;
       const error = dispatchError.registry.findMetaError(module);
 
-      return (
-        `${error.section}.${error.name}: ${error.docs[0]}` ??
-        `${error.section}.${error.name}`
-      );
+      return `${error.section}.${error.name}: ${error.docs[0]}` ?? `${error.section}.${error.name}`;
     } catch {}
   }
 

--- a/src/dispatchError.ts
+++ b/src/dispatchError.ts
@@ -1,19 +1,19 @@
-import { DispatchError } from "@polkadot/types/interfaces"
+import { DispatchError } from "@polkadot/types/interfaces";
 
 export function extractDispatchErrorDescription(
   dispatchError: DispatchError
 ): string {
   if (dispatchError.isModule) {
     try {
-      const module = dispatchError.asModule
-      const error = dispatchError.registry.findMetaError(module)
+      const module = dispatchError.asModule;
+      const error = dispatchError.registry.findMetaError(module);
 
       return (
         `${error.section}.${error.name}: ${error.docs[0]}` ??
         `${error.section}.${error.name}`
-      )
+      );
     } catch {}
   }
 
-  return dispatchError.type.toString()
+  return dispatchError.type.toString();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,16 @@
-import { ApiPromise } from "@polkadot/api"
-import { BN_ZERO } from "@polkadot/util"
-import { ContractPromise } from "@polkadot/api-contract"
-import { EventRecord, Hash, Weight, WeightV2 } from "@polkadot/types/interfaces"
-import { AnyJson } from "@polkadot/types-codec/types"
-import { Abi } from "@polkadot/api-contract"
+import { ApiPromise } from "@polkadot/api";
+import { BN_ZERO } from "@polkadot/util";
+import { ContractPromise } from "@polkadot/api-contract";
+import {
+  EventRecord,
+  Hash,
+  Weight,
+  WeightV2,
+} from "@polkadot/types/interfaces";
+import { AnyJson } from "@polkadot/types-codec/types";
+import { Abi } from "@polkadot/api-contract";
 
-import { PanicCode, rpcCall } from "./contractRpc.js"
+import { PanicCode, rpcCall } from "./contractRpc.js";
 import {
   Extrinsic,
   GenericSigner,
@@ -15,9 +20,9 @@ import {
   signAndSubmitExtrinsic,
   submitExtrinsic,
   signExtrinsic,
-} from "./submitExtrinsic.js"
-import { addressEq } from "@polkadot/util-crypto"
-import { basicDeployContract } from "./deployContract.js"
+} from "./submitExtrinsic.js";
+import { addressEq } from "@polkadot/util-crypto";
+import { basicDeployContract } from "./deployContract.js";
 
 export {
   PanicCode,
@@ -29,113 +34,113 @@ export {
   signExtrinsic,
   submitExtrinsic,
   signAndSubmitExtrinsic,
-}
+};
 
-export type Address = string
+export type Address = string;
 
 export interface Limits {
   gas: {
-    refTime: string | number
-    proofSize: string | number
-  }
-  storageDeposit?: string | number
+    refTime: string | number;
+    proofSize: string | number;
+  };
+  storageDeposit?: string | number;
 }
 
 export interface DecodedContractEvent {
-  eventIdentifier: string
-  args: { name: string; value: AnyJson }[]
+  eventIdentifier: string;
+  args: { name: string; value: AnyJson }[];
 }
 
 export interface ContractEvent {
-  emittingContractAddress: Address
-  data: Uint8Array
-  decoded?: DecodedContractEvent
+  emittingContractAddress: Address;
+  data: Uint8Array;
+  decoded?: DecodedContractEvent;
 }
 
 export interface DeployContractOptions {
-  abi: Abi
-  api: ApiPromise
-  signer: KeyPairSigner | GenericSigner
-  constructorArguments: unknown[]
-  constructorName?: string
-  limits: Limits
-  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic
-  lookupAbi?: (contractAddress: Address) => Abi | undefined
+  abi: Abi;
+  api: ApiPromise;
+  signer: KeyPairSigner | GenericSigner;
+  constructorArguments: unknown[];
+  constructorName?: string;
+  limits: Limits;
+  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic;
+  lookupAbi?: (contractAddress: Address) => Abi | undefined;
 }
 
 export type DeployContractResult =
   | {
-      type: "success"
-      events: ContractEvent[]
-      deploymentAddress: Address
-      transactionFee: bigint | undefined
+      type: "success";
+      events: ContractEvent[];
+      deploymentAddress: Address;
+      transactionFee: bigint | undefined;
     }
   | { type: "error"; error: string }
   | { type: "reverted"; description: string }
-  | { type: "panic"; errorCode: PanicCode; explanation: string }
+  | { type: "panic"; errorCode: PanicCode; explanation: string };
 
 export interface CreateExecuteMessageExtrinsicOptions {
-  abi: Abi
-  api: ApiPromise
-  contractDeploymentAddress: Address
-  callerAddress: Address
-  messageName: string
-  messageArguments: unknown[]
-  limits: Limits
-  gasLimitTolerancePercentage?: number
-  skipDryRunning?: boolean
+  abi: Abi;
+  api: ApiPromise;
+  contractDeploymentAddress: Address;
+  callerAddress: Address;
+  messageName: string;
+  messageArguments: unknown[];
+  limits: Limits;
+  gasLimitTolerancePercentage?: number;
+  skipDryRunning?: boolean;
 }
 
 export type CreateExecuteMessageExtrinsicResult = {
-  execution: { type: "onlyRpc" } | { type: "extrinsic"; extrinsic: Extrinsic }
-  result?: ReadMessageResult
-}
+  execution: { type: "onlyRpc" } | { type: "extrinsic"; extrinsic: Extrinsic };
+  result?: ReadMessageResult;
+};
 
 export interface ExecuteMessageOptions
   extends CreateExecuteMessageExtrinsicOptions {
-  getSigner: () => Promise<KeyPairSigner | GenericSigner>
-  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic
-  lookupAbi?: (contractAddress: Address) => Abi | undefined
+  getSigner: () => Promise<KeyPairSigner | GenericSigner>;
+  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic;
+  lookupAbi?: (contractAddress: Address) => Abi | undefined;
 }
 
 export type ExecuteMessageResult = {
   execution:
     | { type: "onlyRpc" }
     | {
-        type: "extrinsic"
-        contractEvents: ContractEvent[]
-        transactionFee: bigint | undefined
-        txHash: Hash
-        txIndex?: number | undefined
-      }
-  result?: ReadMessageResult
-}
+        type: "extrinsic";
+        contractEvents: ContractEvent[];
+        transactionFee: bigint | undefined;
+        txHash: Hash;
+        txIndex?: number | undefined;
+      };
+  result?: ReadMessageResult;
+};
 
 export interface ReadMessageOptions {
-  abi: Abi
-  api: ApiPromise
-  contractDeploymentAddress: Address
-  callerAddress: Address
-  messageName: string
-  messageArguments: unknown[]
-  limits: Limits
+  abi: Abi;
+  api: ApiPromise;
+  contractDeploymentAddress: Address;
+  callerAddress: Address;
+  messageName: string;
+  messageArguments: unknown[];
+  limits: Limits;
 }
 
 export type GasMetrics = {
-  gasRequired: Weight
-  gasConsumed: Weight
-}
+  gasRequired: Weight;
+  gasConsumed: Weight;
+};
 
 export type ReadMessageResult =
   | { type: "success"; gasMetrics: GasMetrics; value: any }
   | { type: "error"; gasMetrics: GasMetrics; error: string }
   | { type: "reverted"; gasMetrics: GasMetrics; description: string }
   | {
-      type: "panic"
-      gasMetrics: GasMetrics
-      errorCode: PanicCode
-      explanation: string
-    }
+      type: "panic";
+      gasMetrics: GasMetrics;
+      errorCode: PanicCode;
+      explanation: string;
+    };
 
 function decodeContractEvents(
   eventRecords: EventRecord[],
@@ -148,26 +153,27 @@ function decodeContractEvents(
     )
     .map((eventRecord): ContractEvent => {
       const dataJson = eventRecord.event.data.toHuman() as {
-        contract: string
-        data: string
-      }
-      const emittingContractAddress = dataJson.contract
+        contract: string;
+        data: string;
+      };
+      const emittingContractAddress = dataJson.contract;
 
-      let dataHexString = dataJson.data
-      if (dataHexString.startsWith("0x")) dataHexString = dataHexString.slice(2)
-      const data = new Uint8Array(dataHexString.length / 2)
+      let dataHexString = dataJson.data;
+      if (dataHexString.startsWith("0x"))
+        dataHexString = dataHexString.slice(2);
+      const data = new Uint8Array(dataHexString.length / 2);
       for (let i = 0; i * 2 < dataHexString.length; i += 1) {
-        data[i] = parseInt(dataHexString.slice(i * 2, i * 2 + 2), 16)
+        data[i] = parseInt(dataHexString.slice(i * 2, i * 2 + 2), 16);
       }
 
-      const abi = lookupAbi?.(emittingContractAddress)
+      const abi = lookupAbi?.(emittingContractAddress);
       if (abi === undefined) {
         return {
           emittingContractAddress,
           data,
-        }
+        };
       }
-      const decodedEvent = abi.decodeEvent(eventRecord)
+      const decodedEvent = abi.decodeEvent(eventRecord);
 
       return {
         emittingContractAddress,
@@ -179,8 +185,8 @@ function decodeContractEvents(
           })),
           eventIdentifier: decodedEvent.event.identifier,
         },
-      }
-    })
+      };
+    });
 }
 
 export async function deployContract({
@@ -201,51 +207,51 @@ export async function deployContract({
     limits,
     signer,
     modifyExtrinsic,
-  })
+  });
 
   switch (result.type) {
     case "panic":
     case "reverted":
     case "error":
-      return result
+      return result;
   }
 
   const extendedLookupAbi = (contractAddress: Address): Abi | undefined => {
     if (addressEq(contractAddress, result.deploymentAddress)) {
-      return abi
+      return abi;
     }
 
-    return lookupAbi?.(contractAddress)
-  }
+    return lookupAbi?.(contractAddress);
+  };
 
   return {
     ...result,
     events: decodeContractEvents(result.eventRecords, extendedLookupAbi),
-  }
+  };
 }
 
 export async function executeMessage(
   options: ExecuteMessageOptions
 ): Promise<ExecuteMessageResult> {
-  const { getSigner, modifyExtrinsic, lookupAbi } = options
+  const { getSigner, modifyExtrinsic, lookupAbi } = options;
   const { execution, result: readMessageResult } =
-    await createExecuteMessageExtrinsic(options)
+    await createExecuteMessageExtrinsic(options);
 
   if (execution.type === "onlyRpc") {
     return {
       execution,
       result: readMessageResult,
-    }
+    };
   }
 
-  let { extrinsic } = execution
+  let { extrinsic } = execution;
   if (modifyExtrinsic) {
-    extrinsic = modifyExtrinsic(extrinsic)
+    extrinsic = modifyExtrinsic(extrinsic);
   }
 
-  const signer = await getSigner()
+  const signer = await getSigner();
   const { eventRecords, status, transactionFee, txIndex, txHash } =
-    await signAndSubmitExtrinsic(extrinsic, signer)
+    await signAndSubmitExtrinsic(extrinsic, signer);
 
   return {
     execution: {
@@ -259,7 +265,7 @@ export async function executeMessage(
       status.type === "success" || readMessageResult === undefined
         ? readMessageResult
         : { ...status, gasMetrics: readMessageResult.gasMetrics },
-  }
+  };
 }
 
 export async function createExecuteMessageExtrinsic({
@@ -273,13 +279,13 @@ export async function createExecuteMessageExtrinsic({
   gasLimitTolerancePercentage = 10,
   skipDryRunning,
 }: CreateExecuteMessageExtrinsicOptions): Promise<CreateExecuteMessageExtrinsicResult> {
-  const contract = new ContractPromise(api, abi, contractDeploymentAddress)
+  const contract = new ContractPromise(api, abi, contractDeploymentAddress);
 
-  let gasRequired: WeightV2
-  let readMessageResult: ReadMessageResult | undefined
+  let gasRequired: WeightV2;
+  let readMessageResult: ReadMessageResult | undefined;
 
   if (skipDryRunning === true) {
-    gasRequired = api.createType("WeightV2", limits.gas)
+    gasRequired = api.createType("WeightV2", limits.gas);
   } else {
     readMessageResult = await readMessage({
       api,
@@ -289,13 +295,13 @@ export async function createExecuteMessageExtrinsic({
       messageName,
       messageArguments,
       limits,
-    })
+    });
 
     if (readMessageResult.type !== "success") {
-      return { execution: { type: "onlyRpc" }, result: readMessageResult }
+      return { execution: { type: "onlyRpc" }, result: readMessageResult };
     }
 
-    gasRequired = readMessageResult.gasMetrics.gasRequired
+    gasRequired = readMessageResult.gasMetrics.gasRequired;
     if (gasLimitTolerancePercentage > 0) {
       gasRequired = api.createType("WeightV2", {
         refTime:
@@ -306,44 +312,44 @@ export async function createExecuteMessageExtrinsic({
           (gasRequired.proofSize.toBigInt() *
             (100n + BigInt(gasLimitTolerancePercentage))) /
           100n,
-      })
+      });
     }
   }
 
   const typesAddress = api.registry.createType(
     "AccountId",
     contractDeploymentAddress
-  )
+  );
   let extrinsic = api.tx.contracts.call(
     typesAddress,
     BN_ZERO,
     gasRequired,
     limits.storageDeposit,
     contract.abi.findMessage(messageName).toU8a(messageArguments)
-  )
+  );
 
   return {
     execution: { type: "extrinsic", extrinsic },
     result: readMessageResult,
-  }
+  };
 }
 
 export async function submitExecuteMessageExtrinsic(
   extrinsic: Extrinsic,
   lookupAbi?: (contractAddress: Address) => Abi | undefined
 ): Promise<{
-  contractEvents: ContractEvent[]
-  transactionFee: bigint | undefined
-  status: SubmitExtrinsicStatus
+  contractEvents: ContractEvent[];
+  transactionFee: bigint | undefined;
+  status: SubmitExtrinsicStatus;
 }> {
   const { eventRecords, status, transactionFee } =
-    await submitExtrinsic(extrinsic)
+    await submitExtrinsic(extrinsic);
 
   return {
     contractEvents: decodeContractEvents(eventRecords, lookupAbi),
     transactionFee,
     status,
-  }
+  };
 }
 
 export async function readMessage({
@@ -363,21 +369,21 @@ export async function readMessage({
     limits,
     messageName,
     messageArguments,
-  })
+  });
 
-  const gasMetrics = { gasRequired, gasConsumed }
+  const gasMetrics = { gasRequired, gasConsumed };
 
   switch (output.type) {
     case "success":
     case "reverted":
     case "panic":
-      return { ...output, gasMetrics }
+      return { ...output, gasMetrics };
 
     case "error":
       return {
         type: "error",
         error: output.description ?? "unknown",
         gasMetrics,
-      }
+      };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 import { ApiPromise } from "@polkadot/api";
 import { BN_ZERO } from "@polkadot/util";
 import { ContractPromise } from "@polkadot/api-contract";
-import {
-  EventRecord,
-  Hash,
-  Weight,
-  WeightV2,
-} from "@polkadot/types/interfaces";
+import { EventRecord, Hash, Weight, WeightV2 } from "@polkadot/types/interfaces";
 import { AnyJson } from "@polkadot/types-codec/types";
 import { Abi } from "@polkadot/api-contract";
 
@@ -96,8 +91,7 @@ export type CreateExecuteMessageExtrinsicResult = {
   result?: ReadMessageResult;
 };
 
-export interface ExecuteMessageOptions
-  extends CreateExecuteMessageExtrinsicOptions {
+export interface ExecuteMessageOptions extends CreateExecuteMessageExtrinsicOptions {
   getSigner: () => Promise<KeyPairSigner | GenericSigner>;
   modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic;
   lookupAbi?: (contractAddress: Address) => Abi | undefined;
@@ -147,10 +141,7 @@ function decodeContractEvents(
   lookupAbi?: (contractAddress: Address) => Abi | undefined
 ): ContractEvent[] {
   return eventRecords
-    .filter(
-      ({ event: { section, method } }) =>
-        section === "contracts" && method === "ContractEmitted"
-    )
+    .filter(({ event: { section, method } }) => section === "contracts" && method === "ContractEmitted")
     .map((eventRecord): ContractEvent => {
       const dataJson = eventRecord.event.data.toHuman() as {
         contract: string;
@@ -159,8 +150,7 @@ function decodeContractEvents(
       const emittingContractAddress = dataJson.contract;
 
       let dataHexString = dataJson.data;
-      if (dataHexString.startsWith("0x"))
-        dataHexString = dataHexString.slice(2);
+      if (dataHexString.startsWith("0x")) dataHexString = dataHexString.slice(2);
       const data = new Uint8Array(dataHexString.length / 2);
       for (let i = 0; i * 2 < dataHexString.length; i += 1) {
         data[i] = parseInt(dataHexString.slice(i * 2, i * 2 + 2), 16);
@@ -230,12 +220,9 @@ export async function deployContract({
   };
 }
 
-export async function executeMessage(
-  options: ExecuteMessageOptions
-): Promise<ExecuteMessageResult> {
+export async function executeMessage(options: ExecuteMessageOptions): Promise<ExecuteMessageResult> {
   const { getSigner, modifyExtrinsic, lookupAbi } = options;
-  const { execution, result: readMessageResult } =
-    await createExecuteMessageExtrinsic(options);
+  const { execution, result: readMessageResult } = await createExecuteMessageExtrinsic(options);
 
   if (execution.type === "onlyRpc") {
     return {
@@ -250,8 +237,7 @@ export async function executeMessage(
   }
 
   const signer = await getSigner();
-  const { eventRecords, status, transactionFee, txIndex, txHash } =
-    await signAndSubmitExtrinsic(extrinsic, signer);
+  const { eventRecords, status, transactionFee, txIndex, txHash } = await signAndSubmitExtrinsic(extrinsic, signer);
 
   return {
     execution: {
@@ -304,22 +290,13 @@ export async function createExecuteMessageExtrinsic({
     gasRequired = readMessageResult.gasMetrics.gasRequired;
     if (gasLimitTolerancePercentage > 0) {
       gasRequired = api.createType("WeightV2", {
-        refTime:
-          (gasRequired.refTime.toBigInt() *
-            (100n + BigInt(gasLimitTolerancePercentage))) /
-          100n,
-        proofSize:
-          (gasRequired.proofSize.toBigInt() *
-            (100n + BigInt(gasLimitTolerancePercentage))) /
-          100n,
+        refTime: (gasRequired.refTime.toBigInt() * (100n + BigInt(gasLimitTolerancePercentage))) / 100n,
+        proofSize: (gasRequired.proofSize.toBigInt() * (100n + BigInt(gasLimitTolerancePercentage))) / 100n,
       });
     }
   }
 
-  const typesAddress = api.registry.createType(
-    "AccountId",
-    contractDeploymentAddress
-  );
+  const typesAddress = api.registry.createType("AccountId", contractDeploymentAddress);
   let extrinsic = api.tx.contracts.call(
     typesAddress,
     BN_ZERO,
@@ -342,8 +319,7 @@ export async function submitExecuteMessageExtrinsic(
   transactionFee: bigint | undefined;
   status: SubmitExtrinsicStatus;
 }> {
-  const { eventRecords, status, transactionFee } =
-    await submitExtrinsic(extrinsic);
+  const { eventRecords, status, transactionFee } = await submitExtrinsic(extrinsic);
 
   return {
     contractEvents: decodeContractEvents(eventRecords, lookupAbi),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import { ApiPromise } from "@polkadot/api";
 import { BN_ZERO } from "@polkadot/util";
 import { ContractPromise } from "@polkadot/api-contract";
-import { EventRecord, Weight, WeightV2 } from "@polkadot/types/interfaces";
+import { EventRecord, Hash, Weight, WeightV2 } from "@polkadot/types/interfaces";
 import { AnyJson } from "@polkadot/types-codec/types";
 import { Abi } from "@polkadot/api-contract";
-import { AddressOrPair, SignerOptions } from "@polkadot/api/types";
 
 import { PanicCode, rpcCall } from "./contractRpc.js";
 import {
@@ -96,7 +95,7 @@ export interface ExecuteMessageOptions extends CreateExecuteMessageExtrinsicOpti
 export type ExecuteMessageResult = {
   execution:
     | { type: "onlyRpc" }
-    | { type: "extrinsic"; contractEvents: ContractEvent[]; transactionFee: bigint | undefined };
+    | { type: "extrinsic";  contractEvents: ContractEvent[]; transactionFee: bigint | undefined, txHash: Hash, txIndex?: number | undefined };
   result?: ReadMessageResult;
 };
 
@@ -216,10 +215,10 @@ export async function executeMessage(options: ExecuteMessageOptions): Promise<Ex
   }
 
   const signer = await getSigner();
-  const { eventRecords, status, transactionFee } = await signAndSubmitExtrinsic(extrinsic, signer);
+  const { eventRecords, status, transactionFee, txIndex, txHash } = await signAndSubmitExtrinsic(extrinsic, signer);
 
   return {
-    execution: { type: "extrinsic", contractEvents: decodeContractEvents(eventRecords, lookupAbi), transactionFee },
+    execution: { type: "extrinsic", contractEvents: decodeContractEvents(eventRecords, lookupAbi), transactionFee, txIndex, txHash },
     result:
       status.type === "success" || readMessageResult === undefined
         ? readMessageResult

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import { ApiPromise } from "@polkadot/api";
-import { BN_ZERO } from "@polkadot/util";
-import { ContractPromise } from "@polkadot/api-contract";
-import { EventRecord, Hash, Weight, WeightV2 } from "@polkadot/types/interfaces";
-import { AnyJson } from "@polkadot/types-codec/types";
-import { Abi } from "@polkadot/api-contract";
+import { ApiPromise } from "@polkadot/api"
+import { BN_ZERO } from "@polkadot/util"
+import { ContractPromise } from "@polkadot/api-contract"
+import { EventRecord, Hash, Weight, WeightV2 } from "@polkadot/types/interfaces"
+import { AnyJson } from "@polkadot/types-codec/types"
+import { Abi } from "@polkadot/api-contract"
 
-import { PanicCode, rpcCall } from "./contractRpc.js";
+import { PanicCode, rpcCall } from "./contractRpc.js"
 import {
   Extrinsic,
   GenericSigner,
@@ -15,9 +15,9 @@ import {
   signAndSubmitExtrinsic,
   submitExtrinsic,
   signExtrinsic,
-} from "./submitExtrinsic.js";
-import { addressEq } from "@polkadot/util-crypto";
-import { basicDeployContract } from "./deployContract.js";
+} from "./submitExtrinsic.js"
+import { addressEq } from "@polkadot/util-crypto"
+import { basicDeployContract } from "./deployContract.js"
 
 export {
   PanicCode,
@@ -29,122 +29,145 @@ export {
   signExtrinsic,
   submitExtrinsic,
   signAndSubmitExtrinsic,
-};
+}
 
-export type Address = string;
+export type Address = string
 
 export interface Limits {
   gas: {
-    refTime: string | number;
-    proofSize: string | number;
-  };
-  storageDeposit?: string | number;
+    refTime: string | number
+    proofSize: string | number
+  }
+  storageDeposit?: string | number
 }
 
 export interface DecodedContractEvent {
-  eventIdentifier: string;
-  args: { name: string; value: AnyJson }[];
+  eventIdentifier: string
+  args: { name: string; value: AnyJson }[]
 }
 
 export interface ContractEvent {
-  emittingContractAddress: Address;
-  data: Uint8Array;
-  decoded?: DecodedContractEvent;
+  emittingContractAddress: Address
+  data: Uint8Array
+  decoded?: DecodedContractEvent
 }
 
 export interface DeployContractOptions {
-  abi: Abi;
-  api: ApiPromise;
-  signer: KeyPairSigner | GenericSigner;
-  constructorArguments: unknown[];
-  constructorName?: string;
-  limits: Limits;
-  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic;
-  lookupAbi?: (contractAddress: Address) => Abi | undefined;
+  abi: Abi
+  api: ApiPromise
+  signer: KeyPairSigner | GenericSigner
+  constructorArguments: unknown[]
+  constructorName?: string
+  limits: Limits
+  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic
+  lookupAbi?: (contractAddress: Address) => Abi | undefined
 }
 
 export type DeployContractResult =
-  | { type: "success"; events: ContractEvent[]; deploymentAddress: Address; transactionFee: bigint | undefined }
+  | {
+      type: "success"
+      events: ContractEvent[]
+      deploymentAddress: Address
+      transactionFee: bigint | undefined
+    }
   | { type: "error"; error: string }
   | { type: "reverted"; description: string }
-  | { type: "panic"; errorCode: PanicCode; explanation: string };
+  | { type: "panic"; errorCode: PanicCode; explanation: string }
 
 export interface CreateExecuteMessageExtrinsicOptions {
-  abi: Abi;
-  api: ApiPromise;
-  contractDeploymentAddress: Address;
-  callerAddress: Address;
-  messageName: string;
-  messageArguments: unknown[];
-  limits: Limits;
-  gasLimitTolerancePercentage?: number;
-  skipDryRunning?: boolean;
+  abi: Abi
+  api: ApiPromise
+  contractDeploymentAddress: Address
+  callerAddress: Address
+  messageName: string
+  messageArguments: unknown[]
+  limits: Limits
+  gasLimitTolerancePercentage?: number
+  skipDryRunning?: boolean
 }
 
 export type CreateExecuteMessageExtrinsicResult = {
-  execution: { type: "onlyRpc" } | { type: "extrinsic"; extrinsic: Extrinsic };
-  result?: ReadMessageResult;
-};
+  execution: { type: "onlyRpc" } | { type: "extrinsic"; extrinsic: Extrinsic }
+  result?: ReadMessageResult
+}
 
-export interface ExecuteMessageOptions extends CreateExecuteMessageExtrinsicOptions {
-  getSigner: () => Promise<KeyPairSigner | GenericSigner>;
-  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic;
-  lookupAbi?: (contractAddress: Address) => Abi | undefined;
+export interface ExecuteMessageOptions
+  extends CreateExecuteMessageExtrinsicOptions {
+  getSigner: () => Promise<KeyPairSigner | GenericSigner>
+  modifyExtrinsic?: (extrinsic: Extrinsic) => Extrinsic
+  lookupAbi?: (contractAddress: Address) => Abi | undefined
 }
 
 export type ExecuteMessageResult = {
   execution:
     | { type: "onlyRpc" }
-    | { type: "extrinsic";  contractEvents: ContractEvent[]; transactionFee: bigint | undefined, txHash: Hash, txIndex?: number | undefined };
-  result?: ReadMessageResult;
-};
+    | {
+        type: "extrinsic"
+        contractEvents: ContractEvent[]
+        transactionFee: bigint | undefined
+        txHash: Hash
+        txIndex?: number | undefined
+      }
+  result?: ReadMessageResult
+}
 
 export interface ReadMessageOptions {
-  abi: Abi;
-  api: ApiPromise;
-  contractDeploymentAddress: Address;
-  callerAddress: Address;
-  messageName: string;
-  messageArguments: unknown[];
-  limits: Limits;
+  abi: Abi
+  api: ApiPromise
+  contractDeploymentAddress: Address
+  callerAddress: Address
+  messageName: string
+  messageArguments: unknown[]
+  limits: Limits
 }
 
 export type GasMetrics = {
-  gasRequired: Weight;
-  gasConsumed: Weight;
-};
+  gasRequired: Weight
+  gasConsumed: Weight
+}
 
 export type ReadMessageResult =
   | { type: "success"; gasMetrics: GasMetrics; value: any }
   | { type: "error"; gasMetrics: GasMetrics; error: string }
   | { type: "reverted"; gasMetrics: GasMetrics; description: string }
-  | { type: "panic"; gasMetrics: GasMetrics; errorCode: PanicCode; explanation: string };
+  | {
+      type: "panic"
+      gasMetrics: GasMetrics
+      errorCode: PanicCode
+      explanation: string
+    }
 
 function decodeContractEvents(
   eventRecords: EventRecord[],
   lookupAbi?: (contractAddress: Address) => Abi | undefined
 ): ContractEvent[] {
   return eventRecords
-    .filter(({ event: { section, method } }) => section === "contracts" && method === "ContractEmitted")
+    .filter(
+      ({ event: { section, method } }) =>
+        section === "contracts" && method === "ContractEmitted"
+    )
     .map((eventRecord): ContractEvent => {
-      const dataJson = eventRecord.event.data.toHuman() as { contract: string; data: string };
-      const emittingContractAddress = dataJson.contract;
+      const dataJson = eventRecord.event.data.toHuman() as {
+        contract: string
+        data: string
+      }
+      const emittingContractAddress = dataJson.contract
 
-      let dataHexString = dataJson.data;
-      if (dataHexString.startsWith("0x")) dataHexString = dataHexString.slice(2);
-      const data = new Uint8Array(dataHexString.length / 2);
+      let dataHexString = dataJson.data
+      if (dataHexString.startsWith("0x")) dataHexString = dataHexString.slice(2)
+      const data = new Uint8Array(dataHexString.length / 2)
       for (let i = 0; i * 2 < dataHexString.length; i += 1) {
-        data[i] = parseInt(dataHexString.slice(i * 2, i * 2 + 2), 16);
+        data[i] = parseInt(dataHexString.slice(i * 2, i * 2 + 2), 16)
       }
 
-      const abi = lookupAbi?.(emittingContractAddress);
+      const abi = lookupAbi?.(emittingContractAddress)
       if (abi === undefined) {
         return {
           emittingContractAddress,
           data,
-        };
+        }
       }
-      const decodedEvent = abi.decodeEvent(eventRecord);
+      const decodedEvent = abi.decodeEvent(eventRecord)
 
       return {
         emittingContractAddress,
@@ -156,8 +179,8 @@ function decodeContractEvents(
           })),
           eventIdentifier: decodedEvent.event.identifier,
         },
-      };
-    });
+      }
+    })
 }
 
 export async function deployContract({
@@ -178,52 +201,65 @@ export async function deployContract({
     limits,
     signer,
     modifyExtrinsic,
-  });
+  })
 
   switch (result.type) {
     case "panic":
     case "reverted":
     case "error":
-      return result;
+      return result
   }
 
   const extendedLookupAbi = (contractAddress: Address): Abi | undefined => {
     if (addressEq(contractAddress, result.deploymentAddress)) {
-      return abi;
+      return abi
     }
 
-    return lookupAbi?.(contractAddress);
-  };
+    return lookupAbi?.(contractAddress)
+  }
 
-  return { ...result, events: decodeContractEvents(result.eventRecords, extendedLookupAbi) };
+  return {
+    ...result,
+    events: decodeContractEvents(result.eventRecords, extendedLookupAbi),
+  }
 }
 
-export async function executeMessage(options: ExecuteMessageOptions): Promise<ExecuteMessageResult> {
-  const { getSigner, modifyExtrinsic, lookupAbi } = options;
-  const { execution, result: readMessageResult } = await createExecuteMessageExtrinsic(options);
+export async function executeMessage(
+  options: ExecuteMessageOptions
+): Promise<ExecuteMessageResult> {
+  const { getSigner, modifyExtrinsic, lookupAbi } = options
+  const { execution, result: readMessageResult } =
+    await createExecuteMessageExtrinsic(options)
 
   if (execution.type === "onlyRpc") {
     return {
       execution,
       result: readMessageResult,
-    };
+    }
   }
 
-  let { extrinsic } = execution;
+  let { extrinsic } = execution
   if (modifyExtrinsic) {
-    extrinsic = modifyExtrinsic(extrinsic);
+    extrinsic = modifyExtrinsic(extrinsic)
   }
 
-  const signer = await getSigner();
-  const { eventRecords, status, transactionFee, txIndex, txHash } = await signAndSubmitExtrinsic(extrinsic, signer);
+  const signer = await getSigner()
+  const { eventRecords, status, transactionFee, txIndex, txHash } =
+    await signAndSubmitExtrinsic(extrinsic, signer)
 
   return {
-    execution: { type: "extrinsic", contractEvents: decodeContractEvents(eventRecords, lookupAbi), transactionFee, txIndex, txHash },
+    execution: {
+      type: "extrinsic",
+      contractEvents: decodeContractEvents(eventRecords, lookupAbi),
+      transactionFee,
+      txIndex,
+      txHash,
+    },
     result:
       status.type === "success" || readMessageResult === undefined
         ? readMessageResult
         : { ...status, gasMetrics: readMessageResult.gasMetrics },
-  };
+  }
 }
 
 export async function createExecuteMessageExtrinsic({
@@ -237,13 +273,13 @@ export async function createExecuteMessageExtrinsic({
   gasLimitTolerancePercentage = 10,
   skipDryRunning,
 }: CreateExecuteMessageExtrinsicOptions): Promise<CreateExecuteMessageExtrinsicResult> {
-  const contract = new ContractPromise(api, abi, contractDeploymentAddress);
+  const contract = new ContractPromise(api, abi, contractDeploymentAddress)
 
-  let gasRequired: WeightV2;
-  let readMessageResult: ReadMessageResult | undefined;
+  let gasRequired: WeightV2
+  let readMessageResult: ReadMessageResult | undefined
 
   if (skipDryRunning === true) {
-    gasRequired = api.createType("WeightV2", limits.gas);
+    gasRequired = api.createType("WeightV2", limits.gas)
   } else {
     readMessageResult = await readMessage({
       api,
@@ -253,44 +289,61 @@ export async function createExecuteMessageExtrinsic({
       messageName,
       messageArguments,
       limits,
-    });
+    })
 
     if (readMessageResult.type !== "success") {
-      return { execution: { type: "onlyRpc" }, result: readMessageResult };
+      return { execution: { type: "onlyRpc" }, result: readMessageResult }
     }
 
-    gasRequired = readMessageResult.gasMetrics.gasRequired;
+    gasRequired = readMessageResult.gasMetrics.gasRequired
     if (gasLimitTolerancePercentage > 0) {
       gasRequired = api.createType("WeightV2", {
-        refTime: (gasRequired.refTime.toBigInt() * (100n + BigInt(gasLimitTolerancePercentage))) / 100n,
-        proofSize: (gasRequired.proofSize.toBigInt() * (100n + BigInt(gasLimitTolerancePercentage))) / 100n,
-      });
+        refTime:
+          (gasRequired.refTime.toBigInt() *
+            (100n + BigInt(gasLimitTolerancePercentage))) /
+          100n,
+        proofSize:
+          (gasRequired.proofSize.toBigInt() *
+            (100n + BigInt(gasLimitTolerancePercentage))) /
+          100n,
+      })
     }
   }
 
-  const typesAddress = api.registry.createType("AccountId", contractDeploymentAddress);
+  const typesAddress = api.registry.createType(
+    "AccountId",
+    contractDeploymentAddress
+  )
   let extrinsic = api.tx.contracts.call(
     typesAddress,
     BN_ZERO,
     gasRequired,
     limits.storageDeposit,
     contract.abi.findMessage(messageName).toU8a(messageArguments)
-  );
+  )
 
-  return { execution: { type: "extrinsic", extrinsic }, result: readMessageResult };
+  return {
+    execution: { type: "extrinsic", extrinsic },
+    result: readMessageResult,
+  }
 }
 
 export async function submitExecuteMessageExtrinsic(
   extrinsic: Extrinsic,
   lookupAbi?: (contractAddress: Address) => Abi | undefined
-): Promise<{ contractEvents: ContractEvent[]; transactionFee: bigint | undefined; status: SubmitExtrinsicStatus }> {
-  const { eventRecords, status, transactionFee } = await submitExtrinsic(extrinsic);
+): Promise<{
+  contractEvents: ContractEvent[]
+  transactionFee: bigint | undefined
+  status: SubmitExtrinsicStatus
+}> {
+  const { eventRecords, status, transactionFee } =
+    await submitExtrinsic(extrinsic)
 
   return {
     contractEvents: decodeContractEvents(eventRecords, lookupAbi),
     transactionFee,
     status,
-  };
+  }
 }
 
 export async function readMessage({
@@ -310,21 +363,21 @@ export async function readMessage({
     limits,
     messageName,
     messageArguments,
-  });
+  })
 
-  const gasMetrics = { gasRequired, gasConsumed };
+  const gasMetrics = { gasRequired, gasConsumed }
 
   switch (output.type) {
     case "success":
     case "reverted":
     case "panic":
-      return { ...output, gasMetrics };
+      return { ...output, gasMetrics }
 
     case "error":
       return {
         type: "error",
         error: output.description ?? "unknown",
         gasMetrics,
-      };
+      }
   }
 }

--- a/src/submitExtrinsic.ts
+++ b/src/submitExtrinsic.ts
@@ -1,42 +1,54 @@
-import { AccountId32, DispatchError, DispatchInfo, EventRecord, Hash } from "@polkadot/types/interfaces";
-import { AddressOrPair, SignerOptions, SubmittableExtrinsic } from "@polkadot/api/types";
-import { ISubmittableResult, Signer } from "@polkadot/types/types";
-import { INumber, ITuple } from "@polkadot/types-codec/types";
-import { KeyringPair } from "@polkadot/keyring/types";
+import {
+  AccountId32,
+  DispatchError,
+  DispatchInfo,
+  EventRecord,
+  Hash,
+} from "@polkadot/types/interfaces"
+import {
+  AddressOrPair,
+  SignerOptions,
+  SubmittableExtrinsic,
+} from "@polkadot/api/types"
+import { ISubmittableResult, Signer } from "@polkadot/types/types"
+import { INumber, ITuple } from "@polkadot/types-codec/types"
+import { KeyringPair } from "@polkadot/keyring/types"
 
-import { extractDispatchErrorDescription } from "./dispatchError.js";
-import { Address } from "./index.js";
+import { extractDispatchErrorDescription } from "./dispatchError.js"
+import { Address } from "./index.js"
 
-export type Extrinsic = SubmittableExtrinsic<"promise", ISubmittableResult>;
+export type Extrinsic = SubmittableExtrinsic<"promise", ISubmittableResult>
 
-export type SubmitExtrinsicStatus = { type: "success" } | { type: "error"; error: string };
+export type SubmitExtrinsicStatus =
+  | { type: "success" }
+  | { type: "error"; error: string }
 
 export interface SubmitExtrinsicResult {
-  transactionFee: bigint | undefined;
-  eventRecords: EventRecord[];
-  status: SubmitExtrinsicStatus;
-  txHash: Hash;
-  txIndex?: number | undefined;
+  transactionFee: bigint | undefined
+  eventRecords: EventRecord[]
+  status: SubmitExtrinsicStatus
+  txHash: Hash
+  txIndex?: number | undefined
 }
 
 export interface KeyPairSigner {
-  type: "keypair";
-  keypair: KeyringPair;
+  type: "keypair"
+  keypair: KeyringPair
 }
 
 export interface GenericSigner {
-  type: "signer";
-  address: Address;
-  signer: Signer;
+  type: "signer"
+  address: Address
+  signer: Signer
 }
 
 export function getSignerAddress(signer: KeyPairSigner | GenericSigner) {
   switch (signer.type) {
     case "keypair":
-      return signer.keypair.address;
+      return signer.keypair.address
 
     case "signer":
-      return signer.address;
+      return signer.address
   }
 }
 
@@ -44,64 +56,85 @@ export async function signAndSubmitExtrinsic(
   extrinsic: Extrinsic,
   signer: KeyPairSigner | GenericSigner
 ): Promise<SubmitExtrinsicResult> {
-  const signedExtrinsic = await signExtrinsic(extrinsic, signer);
-  return submitExtrinsic(signedExtrinsic);
+  const signedExtrinsic = await signExtrinsic(extrinsic, signer)
+  return submitExtrinsic(signedExtrinsic)
 }
 
-export async function signExtrinsic(extrinsic: Extrinsic, signer: KeyPairSigner | GenericSigner): Promise<Extrinsic> {
-  let account: AddressOrPair;
-  let signerOptions: Partial<SignerOptions>;
+export async function signExtrinsic(
+  extrinsic: Extrinsic,
+  signer: KeyPairSigner | GenericSigner
+): Promise<Extrinsic> {
+  let account: AddressOrPair
+  let signerOptions: Partial<SignerOptions>
 
   switch (signer.type) {
     case "keypair":
-      account = signer.keypair;
-      signerOptions = { nonce: -1 };
-      break;
+      account = signer.keypair
+      signerOptions = { nonce: -1 }
+      break
 
     case "signer":
-      account = signer.address;
-      signerOptions = { nonce: -1, signer: signer.signer };
-      break;
+      account = signer.address
+      signerOptions = { nonce: -1, signer: signer.signer }
+      break
   }
-  return extrinsic.signAsync(account, signerOptions);
+  return extrinsic.signAsync(account, signerOptions)
 }
 
-export async function submitExtrinsic(extrinsic: Extrinsic): Promise<SubmitExtrinsicResult> {
+export async function submitExtrinsic(
+  extrinsic: Extrinsic
+): Promise<SubmitExtrinsicResult> {
   return await new Promise<SubmitExtrinsicResult>(async (resolve, reject) => {
     try {
       const unsub = await extrinsic.send((update) => {
-        const { status, events: eventRecords, txHash, txIndex } = update;
+        const { status, events: eventRecords, txHash, txIndex } = update
 
         if (status.isInBlock || status.isFinalized) {
-          let transactionFee: bigint | undefined = undefined;
-          let status: SubmitExtrinsicStatus | undefined = undefined;
+          let transactionFee: bigint | undefined = undefined
+          let status: SubmitExtrinsicStatus | undefined = undefined
 
           for (const eventRecord of eventRecords) {
-            const { data, section, method } = eventRecord.event;
+            const { data, section, method } = eventRecord.event
 
-            if (section === "transactionPayment" && method === "TransactionFeePaid") {
-              const [, actualFee] = data as unknown as ITuple<[AccountId32, INumber, INumber]>;
-              transactionFee = actualFee.toBigInt();
+            if (
+              section === "transactionPayment" &&
+              method === "TransactionFeePaid"
+            ) {
+              const [, actualFee] = data as unknown as ITuple<
+                [AccountId32, INumber, INumber]
+              >
+              transactionFee = actualFee.toBigInt()
             }
 
             if (section === "system" && method === "ExtrinsicFailed") {
-              const [dispatchError] = data as unknown as ITuple<[DispatchError, DispatchInfo]>;
-              status = { type: "error", error: extractDispatchErrorDescription(dispatchError) };
+              const [dispatchError] = data as unknown as ITuple<
+                [DispatchError, DispatchInfo]
+              >
+              status = {
+                type: "error",
+                error: extractDispatchErrorDescription(dispatchError),
+              }
             }
 
             if (section === "system" && method === "ExtrinsicSuccess") {
-              status = { type: "success" };
+              status = { type: "success" }
             }
           }
 
           if (status !== undefined) {
-            unsub();
-            resolve({ transactionFee, eventRecords, status, txHash, txIndex });
+            unsub()
+            resolve({
+              transactionFee,
+              eventRecords,
+              status,
+              txHash,
+              txIndex,
+            })
           }
         }
-      });
+      })
     } catch (error) {
-      reject(error);
+      reject(error)
     }
-  });
+  })
 }

--- a/src/submitExtrinsic.ts
+++ b/src/submitExtrinsic.ts
@@ -4,51 +4,51 @@ import {
   DispatchInfo,
   EventRecord,
   Hash,
-} from "@polkadot/types/interfaces"
+} from "@polkadot/types/interfaces";
 import {
   AddressOrPair,
   SignerOptions,
   SubmittableExtrinsic,
-} from "@polkadot/api/types"
-import { ISubmittableResult, Signer } from "@polkadot/types/types"
-import { INumber, ITuple } from "@polkadot/types-codec/types"
-import { KeyringPair } from "@polkadot/keyring/types"
+} from "@polkadot/api/types";
+import { ISubmittableResult, Signer } from "@polkadot/types/types";
+import { INumber, ITuple } from "@polkadot/types-codec/types";
+import { KeyringPair } from "@polkadot/keyring/types";
 
-import { extractDispatchErrorDescription } from "./dispatchError.js"
-import { Address } from "./index.js"
+import { extractDispatchErrorDescription } from "./dispatchError.js";
+import { Address } from "./index.js";
 
-export type Extrinsic = SubmittableExtrinsic<"promise", ISubmittableResult>
+export type Extrinsic = SubmittableExtrinsic<"promise", ISubmittableResult>;
 
 export type SubmitExtrinsicStatus =
   | { type: "success" }
-  | { type: "error"; error: string }
+  | { type: "error"; error: string };
 
 export interface SubmitExtrinsicResult {
-  transactionFee: bigint | undefined
-  eventRecords: EventRecord[]
-  status: SubmitExtrinsicStatus
-  txHash: Hash
-  txIndex?: number | undefined
+  transactionFee: bigint | undefined;
+  eventRecords: EventRecord[];
+  status: SubmitExtrinsicStatus;
+  txHash: Hash;
+  txIndex?: number | undefined;
 }
 
 export interface KeyPairSigner {
-  type: "keypair"
-  keypair: KeyringPair
+  type: "keypair";
+  keypair: KeyringPair;
 }
 
 export interface GenericSigner {
-  type: "signer"
-  address: Address
-  signer: Signer
+  type: "signer";
+  address: Address;
+  signer: Signer;
 }
 
 export function getSignerAddress(signer: KeyPairSigner | GenericSigner) {
   switch (signer.type) {
     case "keypair":
-      return signer.keypair.address
+      return signer.keypair.address;
 
     case "signer":
-      return signer.address
+      return signer.address;
   }
 }
 
@@ -56,29 +56,29 @@ export async function signAndSubmitExtrinsic(
   extrinsic: Extrinsic,
   signer: KeyPairSigner | GenericSigner
 ): Promise<SubmitExtrinsicResult> {
-  const signedExtrinsic = await signExtrinsic(extrinsic, signer)
-  return submitExtrinsic(signedExtrinsic)
+  const signedExtrinsic = await signExtrinsic(extrinsic, signer);
+  return submitExtrinsic(signedExtrinsic);
 }
 
 export async function signExtrinsic(
   extrinsic: Extrinsic,
   signer: KeyPairSigner | GenericSigner
 ): Promise<Extrinsic> {
-  let account: AddressOrPair
-  let signerOptions: Partial<SignerOptions>
+  let account: AddressOrPair;
+  let signerOptions: Partial<SignerOptions>;
 
   switch (signer.type) {
     case "keypair":
-      account = signer.keypair
-      signerOptions = { nonce: -1 }
-      break
+      account = signer.keypair;
+      signerOptions = { nonce: -1 };
+      break;
 
     case "signer":
-      account = signer.address
-      signerOptions = { nonce: -1, signer: signer.signer }
-      break
+      account = signer.address;
+      signerOptions = { nonce: -1, signer: signer.signer };
+      break;
   }
-  return extrinsic.signAsync(account, signerOptions)
+  return extrinsic.signAsync(account, signerOptions);
 }
 
 export async function submitExtrinsic(
@@ -87,14 +87,14 @@ export async function submitExtrinsic(
   return await new Promise<SubmitExtrinsicResult>(async (resolve, reject) => {
     try {
       const unsub = await extrinsic.send((update) => {
-        const { status, events: eventRecords, txHash, txIndex } = update
+        const { status, events: eventRecords, txHash, txIndex } = update;
 
         if (status.isInBlock || status.isFinalized) {
-          let transactionFee: bigint | undefined = undefined
-          let status: SubmitExtrinsicStatus | undefined = undefined
+          let transactionFee: bigint | undefined = undefined;
+          let status: SubmitExtrinsicStatus | undefined = undefined;
 
           for (const eventRecord of eventRecords) {
-            const { data, section, method } = eventRecord.event
+            const { data, section, method } = eventRecord.event;
 
             if (
               section === "transactionPayment" &&
@@ -102,39 +102,39 @@ export async function submitExtrinsic(
             ) {
               const [, actualFee] = data as unknown as ITuple<
                 [AccountId32, INumber, INumber]
-              >
-              transactionFee = actualFee.toBigInt()
+              >;
+              transactionFee = actualFee.toBigInt();
             }
 
             if (section === "system" && method === "ExtrinsicFailed") {
               const [dispatchError] = data as unknown as ITuple<
                 [DispatchError, DispatchInfo]
-              >
+              >;
               status = {
                 type: "error",
                 error: extractDispatchErrorDescription(dispatchError),
-              }
+              };
             }
 
             if (section === "system" && method === "ExtrinsicSuccess") {
-              status = { type: "success" }
+              status = { type: "success" };
             }
           }
 
           if (status !== undefined) {
-            unsub()
+            unsub();
             resolve({
               transactionFee,
               eventRecords,
               status,
               txHash,
               txIndex,
-            })
+            });
           }
         }
-      })
+      });
     } catch (error) {
-      reject(error)
+      reject(error);
     }
-  })
+  });
 }

--- a/src/submitExtrinsic.ts
+++ b/src/submitExtrinsic.ts
@@ -1,15 +1,5 @@
-import {
-  AccountId32,
-  DispatchError,
-  DispatchInfo,
-  EventRecord,
-  Hash,
-} from "@polkadot/types/interfaces";
-import {
-  AddressOrPair,
-  SignerOptions,
-  SubmittableExtrinsic,
-} from "@polkadot/api/types";
+import { AccountId32, DispatchError, DispatchInfo, EventRecord, Hash } from "@polkadot/types/interfaces";
+import { AddressOrPair, SignerOptions, SubmittableExtrinsic } from "@polkadot/api/types";
 import { ISubmittableResult, Signer } from "@polkadot/types/types";
 import { INumber, ITuple } from "@polkadot/types-codec/types";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -19,9 +9,7 @@ import { Address } from "./index.js";
 
 export type Extrinsic = SubmittableExtrinsic<"promise", ISubmittableResult>;
 
-export type SubmitExtrinsicStatus =
-  | { type: "success" }
-  | { type: "error"; error: string };
+export type SubmitExtrinsicStatus = { type: "success" } | { type: "error"; error: string };
 
 export interface SubmitExtrinsicResult {
   transactionFee: bigint | undefined;
@@ -60,10 +48,7 @@ export async function signAndSubmitExtrinsic(
   return submitExtrinsic(signedExtrinsic);
 }
 
-export async function signExtrinsic(
-  extrinsic: Extrinsic,
-  signer: KeyPairSigner | GenericSigner
-): Promise<Extrinsic> {
+export async function signExtrinsic(extrinsic: Extrinsic, signer: KeyPairSigner | GenericSigner): Promise<Extrinsic> {
   let account: AddressOrPair;
   let signerOptions: Partial<SignerOptions>;
 
@@ -81,9 +66,7 @@ export async function signExtrinsic(
   return extrinsic.signAsync(account, signerOptions);
 }
 
-export async function submitExtrinsic(
-  extrinsic: Extrinsic
-): Promise<SubmitExtrinsicResult> {
+export async function submitExtrinsic(extrinsic: Extrinsic): Promise<SubmitExtrinsicResult> {
   return await new Promise<SubmitExtrinsicResult>(async (resolve, reject) => {
     try {
       const unsub = await extrinsic.send((update) => {
@@ -96,20 +79,13 @@ export async function submitExtrinsic(
           for (const eventRecord of eventRecords) {
             const { data, section, method } = eventRecord.event;
 
-            if (
-              section === "transactionPayment" &&
-              method === "TransactionFeePaid"
-            ) {
-              const [, actualFee] = data as unknown as ITuple<
-                [AccountId32, INumber, INumber]
-              >;
+            if (section === "transactionPayment" && method === "TransactionFeePaid") {
+              const [, actualFee] = data as unknown as ITuple<[AccountId32, INumber, INumber]>;
               transactionFee = actualFee.toBigInt();
             }
 
             if (section === "system" && method === "ExtrinsicFailed") {
-              const [dispatchError] = data as unknown as ITuple<
-                [DispatchError, DispatchInfo]
-              >;
+              const [dispatchError] = data as unknown as ITuple<[DispatchError, DispatchInfo]>;
               status = {
                 type: "error",
                 error: extractDispatchErrorDescription(dispatchError),

--- a/src/submitExtrinsic.ts
+++ b/src/submitExtrinsic.ts
@@ -1,4 +1,4 @@
-import { AccountId32, DispatchError, DispatchInfo, EventRecord } from "@polkadot/types/interfaces";
+import { AccountId32, DispatchError, DispatchInfo, EventRecord, Hash } from "@polkadot/types/interfaces";
 import { AddressOrPair, SignerOptions, SubmittableExtrinsic } from "@polkadot/api/types";
 import { ISubmittableResult, Signer } from "@polkadot/types/types";
 import { INumber, ITuple } from "@polkadot/types-codec/types";
@@ -15,6 +15,8 @@ export interface SubmitExtrinsicResult {
   transactionFee: bigint | undefined;
   eventRecords: EventRecord[];
   status: SubmitExtrinsicStatus;
+  txHash: Hash;
+  txIndex?: number | undefined;
 }
 
 export interface KeyPairSigner {
@@ -68,7 +70,7 @@ export async function submitExtrinsic(extrinsic: Extrinsic): Promise<SubmitExtri
   return await new Promise<SubmitExtrinsicResult>(async (resolve, reject) => {
     try {
       const unsub = await extrinsic.send((update) => {
-        const { status, events: eventRecords } = update;
+        const { status, events: eventRecords, txHash, txIndex } = update;
 
         if (status.isInBlock || status.isFinalized) {
           let transactionFee: bigint | undefined = undefined;
@@ -94,7 +96,7 @@ export async function submitExtrinsic(extrinsic: Extrinsic): Promise<SubmitExtri
 
           if (status !== undefined) {
             unsub();
-            resolve({ transactionFee, eventRecords, status });
+            resolve({ transactionFee, eventRecords, status, txHash, txIndex });
           }
         }
       });


### PR DESCRIPTION
- [x] Expose `txHash` and `txIndex` for from `executeMessage()` result
- [x] Add prettier as precommit hook  and run it on all files

Only the first commit contains relevant code changes. 

Closes #13.